### PR TITLE
Addressing Non-Deterministic Test Failures in EnumDefaultReadTest

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
+++ b/src/main/java/com/fasterxml/jackson/databind/introspect/AnnotatedFieldCollector.java
@@ -70,7 +70,14 @@ public class AnnotatedFieldCollector
         // Let's add super-class' fields first, then ours.
         fields = _findFields(new TypeResolutionContext.Basic(_typeFactory, parent.getBindings()),
                 parent, fields);
-        for (Field f : cls.getDeclaredFields()) {
+        Field[] clsDeclaredFields = cls.getDeclaredFields();
+        Arrays.sort(clsDeclaredFields, new Comparator<Field>() {
+            @Override
+            public int compare(Field field1, Field field2) {
+                return field1.getName().compareTo(field2.getName());
+            }
+        });
+        for (Field f : clsDeclaredFields) {
             // static fields not included (transients are at this point, filtered out later)
             if (!_isIncludableField(f)) {
                 continue;


### PR DESCRIPTION
Issue:
This pull request resolves a test failure in EnumDefaultReadTest.testFirstEnumDefaultValueViaMixin caused by the non-deterministic nature of cls.getDeclaredFields() in the Jackson databind project. The issue arises due to the varying order of fields returned by this method, leading to test failure.

To fix this, the PR introduces a modification to sort the list of fields obtained from cls.getDeclaredFields(). This ensures a consistent and deterministic order of fields, addressing the test failure observed with the [nondex tool](https://github.com/TestingResearchIllinois/NonDex).

Steps to reproduce:
1) git clone https://github.com/FasterXML/jackson-databind
2) cd jackson-databind
3) mvn install -pl . -am -Dskiptests (BUILD SUCCESS)
4) mvn -pl . edu.illinois:nondex-maven-plugin:2.1.1:nondex  -Dtest=com.fasterxml.jackson.databind.deser.enums.EnumDefaultReadTest#testFirstEnumDefaultValueViaMixin
```
Error:
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.027 s <<< FAILURE! -- in com.fasterxml.jackson.databind.deser.enums.EnumDefaultReadTest
[ERROR] com.fasterxml.jackson.databind.deser.enums.EnumDefaultReadTest.testFirstEnumDefaultValueViaMixin -- Time elapsed: 0.021 s <<< FAILURE!
junit.framework.AssertionFailedError: expected:<A> but was:<Z>
```